### PR TITLE
Shallow clone the https://github.com/googleapis/googleapis submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "xtask/proto/googleapis"]
 	path = xtask/proto/googleapis
 	url = https://github.com/googleapis/googleapis.git
+	shallow = true


### PR DESCRIPTION
This reduces the submodule download size from 178M to 18M